### PR TITLE
Replace deprecated `names` by `keys`

### DIFF
--- a/src/generic_io.jl
+++ b/src/generic_io.jl
@@ -207,7 +207,7 @@ end
 
 
 default_datatype(dset::HDF5.Dataset) = AbstractArray{<:RealQuantity,length(size(dset))}
-default_datatype(df::HDF5.H5DataStore) = NamedTuple{(Symbol.(names(df))...,)}
+default_datatype(df::HDF5.H5DataStore) = NamedTuple{(Symbol.(keys(df))...,)}
 
 _size(dset::HDF5.Dataset) = size(dset)
 _size(df::HDF5.H5DataStore) = ()


### PR DESCRIPTION
Using `names` results in an error for me, I guess it should be `keys`:
https://github.com/JuliaIO/HDF5.jl/commit/f01ad317787540426d2ae910c4fdb7ee26662dfe