### PR TITLE
Bugfix in `readdata(..., AbstractArray{<:SVector})`

### DIFF
--- a/src/generic_io.jl
+++ b/src/generic_io.jl
@@ -415,7 +415,7 @@ function LegendDataTypes.readdata(
     input::HDF5.H5DataStore, name::AbstractString,
     AT::Type{<:AbstractArray{<:StaticVector}}
 )
-    N = length(size(input[name])) - 1
+    N = length(size(input[name]))
     data = readdata(input, name, AbstractArray{RealQuantity,N})
     SV = AT.var.ub
     L = size(data, 1)

--- a/src/generic_io.jl
+++ b/src/generic_io.jl
@@ -391,7 +391,7 @@ function LegendDataTypes.readdata(
     input::HDF5.H5DataStore, name::AbstractString,
     AT::Type{<:AbstractArray{<:NTuple}}
 )
-    N = length(size(input[name])) - 1
+    N = length(size(input[name]))
     data = readdata(input, name, AbstractArray{RealQuantity,N})
     SV = AT.var.ub
     L = size(data, 1)


### PR DESCRIPTION
Fix #11

In both cases, `Arrays` of `StaticVectors` or `NTuples` are saved in a flatted way, meaning that a three-dimensional `Array{<:StaticVector}` is saved as four-dimensional `Array`. To avoid the dimension error, `N` needs to be the dimension of the flatted array, not the nested one.