### PR TITLE
Runtests

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -130,7 +130,7 @@ Base.getindex(lh::LVV{T, M}, idxs::LHIndexType...) where {T, M} = begin
 end
 
 Base.getindex(lh::LHRDW, idxs::LHIndexType...) = 
-    ArrayOfRDWaveforms((lh.time[idxs...], lh.value[idxs...]))
+    ArrayOfRDWaveforms((lh.time[idxs...], lh.signal[idxs...]))
 
 _inv_element_ptrs(el_ptr::AbstractVector{<:Int}) = UInt32.(el_ptr .- 1)[2:end]
 Base.isassigned(lh::LH5Array, i::Int) = 1 <= i <= length(lh)
@@ -183,8 +183,8 @@ V<:RealQuantity} = begin
     # and then append time information to on disk array 
     src_t0 = first.(src.time)
     src_dt = step.(src.time)
-    dset_t0 = parent(dest.value.data.file)["t0"]
-    dset_dt = parent(dest.value.data.file)["dt"]
+    dset_t0 = parent(dest.signal.data.file)["t0"]
+    dset_dt = parent(dest.signal.data.file)["dt"]
     append!(LH5Array(dset_t0), src_t0)
     append!(LH5Array(dset_dt), src_dt)
     dest

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,8 @@
 [deps]
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ArraysOfArrays = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+RadiationDetectorSignals = "bf2c0563-65cf-5db2-a620-ceb7de82658c"
+TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ using Test
 Test.@testset "Package LegendHDF5IO" begin
     include("ranges/range_to_namedtuple.jl")
     include("histograms/histogram_io.jl")
+    include("test_wrappers.jl")
 end # testset

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -4,41 +4,90 @@ using TypedTables
 using ArraysOfArrays
 using RadiationDetectorSignals
 
-@testset "reading and writing" begin
-    x = rand(50)
-    y = x*u"J"
-    vofv1 = VectorOfVectors(fill(x, 50))
-    vofv2 = VectorOfVectors(fill(y, 50))
-    aofa1 = nestedview(rand(UInt16, 50, 50))
-    aofa2 = nestedview(rand(UInt16, 50, 50)*u"m")
-    trng = range(0.0u"μs", 10.0u"μs", 50)
-    waveform = ArrayOfRDWaveforms((fill(trng, 50), aofa2))
-    tbl = Table((a=x, b=y, c=vofv1, d=vofv2, e=aofa1, f=waveform))
-    nt = (data1=aofa2, data2=tbl)
-    mktempdir(pwd()) do tmp
-        path = joinpath(tmp, "tmp.lh5")
-        LHDataStore(path, "cw") do f
-            f["tmp"] = nt
+@testset "test wrapper" begin
+    @testset "reading and writing" begin
+        x = rand(50)
+        y = x*u"J"
+        vofv1 = VectorOfVectors(fill(x, 50))
+        vofv2 = VectorOfVectors(fill(y, 50))
+        aofa1 = nestedview(rand(UInt16, 50, 50))
+        aofa2 = nestedview(rand(UInt16, 50, 50)*u"m")
+        trng = range(0.0u"μs", 10.0u"μs", 50)
+        waveform = ArrayOfRDWaveforms((fill(trng, 50), aofa2))
+        tbl = Table((a=x, b=y, c=vofv1, d=vofv2, e=aofa1, f=waveform))
+        nt = (data1=aofa2, data2=tbl)
+        mktempdir(pwd()) do tmp
+            path = joinpath(tmp, "tmp.lh5")
+            LHDataStore(path, "cw") do f
+                f["tmp"] = nt
+            end
+            # now check if datatypes and values are equal to the original 
+            # data, that was written to tmp.lh5
+            LHDataStore(path) do f
+                NT = f["tmp"]
+                @test keys(NT) == keys(nt)
+                @test NT.data1[:] == nt.data1
+                for (col1, col2) in zip(columns(NT.data2), columns(nt.data2))
+                    if isa(col1, ArrayOfRDWaveforms)
+                    @testset "check if RDWaveforms are equal" begin
+                            @test col1.signal == col2.signal
+                            @test col1.time == col2.time
+                    end
+                    else
+                        @test col1 == col2
+                    end
+                end
+            end
         end
-        # now check if datatypes and values are equal to the original 
-        # data, that was written to tmp.lh5
-        LHDataStore(path) do f
-            NT = f["tmp"]
-            @test keys(NT) == keys(nt)
-            @test NT.data1[:] == nt.data1
-            for (col1, col2) in zip(columns(NT.data2), columns(nt.data2))
-                if isa(col1, ArrayOfRDWaveforms)
-                   @testset "check if RDWaveforms are equal" begin
-                        @test col1.signal == col2.signal
-                        @test col1.time == col2.time
-                   end
-                else
-                    @test col1 == col2
+    end
+    @testset "test append functionality" begin
+        x = rand(50)
+        y = x*u"J"
+        vofv1 = VectorOfVectors(collect(eachcol(rand(55, 50))))
+        vofv2 = VectorOfVectors(collect(eachcol(rand(55, 50)*u"m")))
+        aofa1 = nestedview(rand(UInt16, 55, 50))
+        aofa2 = nestedview(rand(UInt16, 55, 50)*u"m")
+        trng = range(0.0u"μs", 10.0u"μs", 55)
+        waveform = ArrayOfRDWaveforms((fill(trng, 50), aofa2))
+        tbl = Table((a=x, b=y, c=vofv1, d=vofv2, e=aofa1, f=waveform))
+        nt = (data1=aofa2, data2=tbl)
+
+        mktempdir(pwd()) do tmp
+            path = joinpath(tmp, "tmp.lh5")
+            LHDataStore(path, "cw") do f
+                f["tmp"] = nt
+            end
+
+            # first append data to in-memory-data
+            nt2 = (data1=vcat(aofa2, aofa2), data2=vcat(tbl, tbl))
+
+            # append data to on-disk-data
+            LHDataStore(path, "cw") do f
+                append!(f["tmp/data1"], aofa2)
+                append!(f["tmp/data2"], tbl)
+                println("size(f[\"tmp/data2\"]) = ", size(f["tmp/data2"]))
+            end
+
+            # now check if datatypes and values are equal to the data 
+            # that was extended in memory
+            println("done appending")
+            LHDataStore(path) do f
+                NT = f["tmp"]
+                println("size(nt2.data2) = ", size(nt2.data2))
+                println("size(NT.data2) = ", size(NT.data2))
+                @test keys(NT) == keys(nt2)
+                @test NT.data1[:] == nt2.data1
+                for (col1, col2) in zip(columns(NT.data2), columns(nt2.data2))
+                    if isa(col1, ArrayOfRDWaveforms)
+                    @testset "check if RDWaveforms are equal" begin
+                            @test col1.signal == col2.signal
+                            @test col1.time == col2.time
+                    end
+                    else
+                        @test col1 == col2
+                    end
                 end
             end
         end
     end
 end
-
-# check append on ArraysOfArrays!
-# check 

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -65,16 +65,12 @@ using RadiationDetectorSignals
             LHDataStore(path, "cw") do f
                 append!(f["tmp/data1"], aofa2)
                 append!(f["tmp/data2"], tbl)
-                println("size(f[\"tmp/data2\"]) = ", size(f["tmp/data2"]))
             end
 
             # now check if datatypes and values are equal to the data 
             # that was extended in memory
-            println("done appending")
             LHDataStore(path) do f
                 NT = f["tmp"]
-                println("size(nt2.data2) = ", size(nt2.data2))
-                println("size(NT.data2) = ", size(NT.data2))
                 @test keys(NT) == keys(nt2)
                 @test NT.data1[:] == nt2.data1
                 for (col1, col2) in zip(columns(NT.data2), columns(nt2.data2))

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -1,0 +1,37 @@
+using LegendHDF5IO
+using Unitful
+using TypedTables
+using ArraysOfArrays
+using RadiationDetectorSignals
+
+@testset "reading and writing" begin
+    x = rand(50)
+    y = x*u"J"
+    vofv1 = VectorOfVectors(fill(x, 50))
+    vofv2 = VectorOfVectors(fill(y, 50))
+    aofa1 = nestedview(rand(UInt16, 50, 50))
+    aofa2 = nestedview(rand(UInt16, 50, 50)*u"m")
+    trng = range(0.0u"μs", 10.0u"μs", 50)
+    waveform = ArrayOfRDWaveforms((fill(trng, 50), aofa2))
+    tbl = Table((a=x, b=y, c=vofv1, d=vofv2, e=aofa1, f=waveform))
+    nt = (data1=aofa2, data2=tbl)
+    mktempdir(pwd()) do tmp
+        path = joinpath(tmp, "tmp.lh5")
+        LHDataStore(path, "cw") do f
+            f["tmp"] = nt
+        end
+        LHDataStore(path) do f
+            NT = f["tmp"]
+            @test keys(NT) == keys(nt)
+            @test NT.data1 == nt.data1
+            for (col1, col2) in zip(columns(NT.data2), columns(nt.data2))
+                println("type: ", typeof(col1))
+                println("\n\n")
+                @test col1[:] == col2[:]
+            end
+        end
+    end
+end
+
+# check append on ArraysOfArrays!
+# check 

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -20,14 +20,21 @@ using RadiationDetectorSignals
         LHDataStore(path, "cw") do f
             f["tmp"] = nt
         end
+        # now check if datatypes and values are equal to the original 
+        # data, that was written to tmp.lh5
         LHDataStore(path) do f
             NT = f["tmp"]
             @test keys(NT) == keys(nt)
-            @test NT.data1 == nt.data1
+            @test NT.data1[:] == nt.data1
             for (col1, col2) in zip(columns(NT.data2), columns(nt.data2))
-                println("type: ", typeof(col1))
-                println("\n\n")
-                @test col1[:] == col2[:]
+                if isa(col1, ArrayOfRDWaveforms)
+                   @testset "check if RDWaveforms are equal" begin
+                        @test col1.signal == col2.signal
+                        @test col1.time == col2.time
+                   end
+                else
+                    @test col1 == col2
+                end
             end
         end
     end


### PR DESCRIPTION
Added runtests which test if getindex, append! and writing of LH5Arrays work for different datatypes.
Also,  adjusted to new Version of RadiationDetectorSignals, where the fieldname changed from `values` to `signal` and
resolved a bug regarding appending of `ArrayOfRDWaveforms`.
Removed/renamed some constant types for better readability.