### PR TITLE
Add `Base.haskey` for `LHDataStore`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -322,6 +322,7 @@ end
 
 Base.close(f::LHDataStore) = close(f.data_store)
 Base.keys(lh::LHDataStore) = keys(lh.data_store)
+Base.haskey(lh::LHDataStore, i::AbstractString) = haskey(lh.data_store, i)
 Base.getindex(lh::LHDataStore, i::AbstractString) = LH5Array(lh.data_store[i])
 
 # write <:Real

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -86,6 +86,14 @@ using StatsBase
             LHDataStore(path) do f
                 NT = f["tmp"]
                 @test keys(NT) == keys(nt2)
+
+                @test haskey(f, "tmp")
+                @test haskey(f, "tmp/data1")
+                @test haskey(f, "tmp/data2")
+                @test !haskey(f, "tmp/data3")
+                @test !haskey(f, "data1")
+                @test !haskey(f, "data2")
+                
                 @test NT.data1[:] == nt2.data1
                 for (col1, col2) in zip(columns(NT.data2), columns(nt2.data2))
                     if isa(col1, ArrayOfRDWaveforms)


### PR DESCRIPTION
I added support for `haskey` which allows to use the `Base.haskey` method in HDF5.jl
https://github.com/JuliaIO/HDF5.jl/blob/9a90e4e5580878b64be2cb70799bf27221f11150/src/groups.jl#L116-L137

This method allows to recursively check if each step of the path exists.

How does that affect `LHDataStore`

```julia
h = LHDataStore("test.lh5", "w")
h["aa/b"] = 2
haskey(h, "aa/b") # used to return false, now returns true
```

Then, calling `haskey` on `LHDataStore` gives results consistent with those for `HDF5.H5DataStore`.