### PR TITLE
Fix `to_table(::AbstractVector{<:RDWaveform}` for non `StructArrays`

### DIFF
--- a/src/LegendHDF5IO.jl
+++ b/src/LegendHDF5IO.jl
@@ -21,7 +21,7 @@ using LegendDataTypes: readdata, writedata, getunits, setunits!,
     read_from_properties, write_to_properties!
 
 using RadiationDetectorSignals: RealQuantity, ArrayOfDims, AosAOfDims, SArrayOfDims,
-    recursive_ndims
+    recursive_ndims, ArrayOfRDWaveforms
 
 
 include("generic_io.jl")

--- a/src/radsig_io.jl
+++ b/src/radsig_io.jl
@@ -1,12 +1,15 @@
 # This file is a part of LegendHDF5IO.jl, licensed under the MIT License (MIT
 
-
-function to_table(x::AbstractVector{<:RDWaveform})
+function to_table(x::ArrayOfRDWaveforms)
     TypedTables.Table(
         t0 = first.(x.time),
         dt = step.(x.time),
         values = x.signal
     )
+end
+
+function to_table(x::AbstractVector{<:RDWaveform})
+    to_table(ArrayOfRDWaveforms(x))
 end
 
 _dtt02range(dt::RealQuantity, t0::RealQuantity, len::Int) =


### PR DESCRIPTION
The current version of `to_table` to save an `AbstractVector{<:RDWaveform}` does only work for `StructArrays`.
In order to also work with other kinds of `Vectors` I have added a method that converts the data to a `StructVector` to then save it. 

@apmypb To my understanding, `to_table` is only used for `writedata`. In the long run, we would like to use `LHDataStore` as the standard for reading and saving data, what would be the (future) implementation of reading and writing (`Vectors` of) `RDWaveforms`?