### PR TITLE
Add missing function to read/write a `Symbol` using `LHDataStore`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -463,7 +463,7 @@ end
 Base.setindex!(output::LHDataStore, v, i::AbstractString, 
 DT::DataType=typeof(v)) = begin
     Tables.istable(v) || throw(ArgumentError("Value to write, of type "
-    *"$(typeof(x)),is not a table"))
+    *"$(typeof(v)),is not a table"))
     cols = Tables.columns(v)
     output[i, typeof(v)] = Tables.columns(v)
     nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -163,9 +163,15 @@ end
 """
     LH5Array(ds::HDF5.Dataset, ::Type{<:String})
 
-return a String object.
+return a `String`.
 """
 LH5Array(ds::HDF5.Dataset, ::Type{<:String}) = read(ds)
+"""
+    LH5Array(ds::HDF5.Dataset, ::Type{<:Symbol})
+
+return a `Symbol`.
+"""
+LH5Array(ds::HDF5.Dataset, ::Type{<:Symbol}) = Symbol(read(ds))
 
 Base.getindex(lh::LH5Array{T, N}, idxs::Vararg{HDF5.IndexType, N}
 ) where {T, N} = begin
@@ -463,7 +469,7 @@ end
 Base.setindex!(output::LHDataStore, v, i::AbstractString, 
 DT::DataType=typeof(v)) = begin
     Tables.istable(v) || throw(ArgumentError("Value to write, of type "
-    *"$(typeof(v)),is not a table"))
+    *"$(typeof(v)), is not a table"))
     cols = Tables.columns(v)
     output[i, typeof(v)] = Tables.columns(v)
     nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -465,6 +465,14 @@ Base.setindex!(output::LHDataStore, v::AbstractString, i::AbstractString
     nothing
 end
 
+# write Symbol
+Base.setindex!(output::LHDataStore, v::Symbol, i::AbstractString
+) = begin 
+    output.data_store[i] = String(v)
+    setdatatype!(output.data_store[i], typeof(v))
+    nothing
+end
+
 # write Table
 Base.setindex!(output::LHDataStore, v, i::AbstractString, 
 DT::DataType=typeof(v)) = begin


### PR DESCRIPTION
`readdata` and `writedata` both were able to save `Symbols` using `LegendHDF5IO`. 
The new implementation with `LHDataStore` did not support this yet.

With this PR, reading and writing `Symbols` will also be supported.