### PR TITLE
Array I/O support for julia-1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .ipynb_checkpoints
 .vscode
 Manifest.toml
+test/*.h5

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendHDF5IO"
 uuid = "c9265ca6-b027-5446-b1a4-febfa8dd10b0"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 ArraysOfArrays = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"

--- a/src/LegendHDF5IO.jl
+++ b/src/LegendHDF5IO.jl
@@ -20,8 +20,7 @@ using LegendDataTypes: readdata, writedata, getunits, setunits!,
     units_from_string, units_to_string,
     read_from_properties, write_to_properties!
 
-using RadiationDetectorSignals: RealQuantity, ArrayOfDims, AosAOfDims, SArrayOfDims,
-    recursive_ndims, ArrayOfRDWaveforms
+using RadiationDetectorSignals: RealQuantity, ArrayOfRDWaveforms
 
 
 include("generic_io.jl")

--- a/src/generic_io.jl
+++ b/src/generic_io.jl
@@ -20,6 +20,8 @@ function _eldatatype_from_string(s::Union{Nothing,AbstractString})
 end
 
 
+_ndims(x) = ndims(x)
+_ndims(::Type{<:AbstractArray{<:Any,N}}) where {N} = N
 
 Base.@propagate_inbounds _tuple_droplast(x::NTuple{N,Any}, ::Val{M}) where {N,M} =
     Base.ntuple(i -> x[i], Val{N-M}())
@@ -310,7 +312,7 @@ function LegendDataTypes.readdata(
     T::Type{<:Union{RealQuantity,AbstractArray}}
 )
     dset = input[name]
-    ndims(dset) == ndims(T) || throw(ArgumentError("Dataset has $(ndims(dset)) dimensions but expected $(ndims(T)) from datatype"))
+    _ndims(dset) == _ndims(T) || throw(ArgumentError("Dataset has $(_ndims(dset)) dimensions but expected $(_ndims(T)) from datatype"))
     data = getcontent(dset)#::AT
     units = getunits(dset)
     if units == NoUnits

--- a/src/types.jl
+++ b/src/types.jl
@@ -50,7 +50,7 @@ const LH5ArrayOfRDWaveforms{T, U, N, VVT} =
     ArrayOfRDWaveforms{T, U, N, VVT, <:Union{LH5VoV{U}, LH5AoSA{U}}}
 const LH5VectorOfRDWaveforms{T, U} = LH5ArrayOfRDWaveforms{T, U, 1}
 
-LH5Array{T}(f::HDF5.Dataset) where {T} = LH5Array{T, ndims(f)}(f)
+LH5Array{T}(f::HDF5.Dataset) where {T} = LH5Array{T, _ndims(f)}(f)
 LH5Array(f::Union{HDF5.Dataset, HDF5.H5DataStore}) = LH5Array(f, getdatatype(f))
 """
     LH5Array(ds::HDF5.Dataset, ::Type{<:RealQuantity})
@@ -104,7 +104,7 @@ return an `ArraysOfSimilarArrays` where the field `data` is a `LH5Array`
 LH5Array(ds::HDF5.Dataset, 
 ::Type{<:AbstractArrayOfSimilarArrays{<:RealQuantity}}) = begin
     A = LH5Array(ds, AbstractArray{<:RealQuantity})
-    D = ndims(A)
+    D = _ndims(A)
     D == 2 ? nestedview(A) : nestedview(A, Val(D - 1))
 end
 """

--- a/test/arrays/arrays_io.jl
+++ b/test/arrays/arrays_io.jl
@@ -1,0 +1,26 @@
+using Unitful
+using LegendHDF5IO: readdata, writedata, LHDataStore
+using HDF5
+
+@testset "Arrays I/O" begin
+    
+    a = rand(typeof(1.0u"keV"), 40)
+    h5open("array_test.h5", "w") do h5f
+        writedata(h5f, "array_in_keV", a)
+        writedata(h5f, "array_no_units", ustrip.(a))
+    end
+
+    @testset "readdata" begin
+        h5open("array_test.h5", "r") do h5f
+            @test readdata(h5f, "array_in_keV") == a
+            @test readdata(h5f, "array_no_units") == ustrip.(a)
+        end
+    end
+
+    @testset "LHDataStore" begin
+        LHDataStore("array_test.h5") do h5f
+            @test h5f["array_in_keV"][:] == a
+            @test h5f["array_no_units"][:] == ustrip.(a)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@
 using Test
 
 Test.@testset "Package LegendHDF5IO" begin
+    include("arrays/arrays_io.jl")
     include("ranges/range_to_namedtuple.jl")
     include("histograms/histogram_io.jl")
     include("test_wrappers.jl")


### PR DESCRIPTION
In the current implementation of I/O of arrays, the number of dimensions cannot be properly checked in julia-1.6 because 
```julia
ndims(AbstractArray{<:RealQuantity, N})
```
is not defined (julia-1.6 does not like the `<:` in the first argument.

Therefore, `ndims` was replaced by `_ndims` which allows for handling this special case for array I/O.