### PR TITLE
Support array_of_encoded_equalsized_arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 ArraysOfArrays = "0.5, 0.6"
 ElasticArrays = "1"
-EncodedArrays = "0.2, 0.3"
+EncodedArrays = "0.4"
 HDF5 = "0.15, 0.16, 0.17"
 LegendDataTypes = "0.1"
 RadiationDetectorSignals = "0.3"

--- a/src/radsig_io.jl
+++ b/src/radsig_io.jl
@@ -18,16 +18,20 @@ _dtt02range(dt::RealQuantity, t0::RealQuantity, len::Int) =
 _dtt02range(dt::AbstractArray, t0::AbstractArray, values) = 
     _dtt02range(dt[axes(dt)...], t0[axes(t0)...], values)
 
-_dtt02range(dt::Array, t0::Array, values::ArrayOfSimilarArrays) =
+_dtt02range(dt::Array, t0::Array, values::AbstractArrayOfSimilarArrays) =
     _dtt02range.(dt, t0, innersize(values)[1])
 
 _dtt02range(dt::Array, t0::Array, values::VectorOfVectors) = 
     _dtt02range.(dt, t0, diff(values.elem_ptr))
 
+_dtt02range(dt::Array, t0::Array, values::VectorOfEncodedArrays) = 
+    _dtt02range.(dt, t0, only.(values.innersizes))
+
 # fallback to default implementation if values is just an array
 _dtt02range(dt, t0, values) = _dtt02range.(dt, t0, size(values, 1))
 
 function from_table(tbl, ::Type{<:AbstractVector{<:RDWaveform}})
+    global g_state = tbl
     StructArray{RDWaveform}((
         _dtt02range(tbl.dt, tbl.t0, tbl.values),
         tbl.values
@@ -52,4 +56,3 @@ function LegendDataTypes.readdata(
     tbl = readdata(input, name, TypedTables.Table{<:NamedTuple{(:t0, :dt, :values)}})
     from_table(tbl, AbstractVector{<:RDWaveform})
 end
-


### PR DESCRIPTION
This works now:
```julia
using LegendDataTypes, LegendHDF5IO, HDF5
using LegendDataTypes: readdata, writedata

f = lh5open("l200-pxx-rxxx-cal-xxxxxxxxTxxxxxxZ-tier_raw.lh5")

ch = "chxxxxxxx"
chds = f.data_store[ch]

data = readdata(chds, "raw")

pwfs = data.waveform_presummed
wwfs = data.waveform_windowed

data_dec = decode_data(data)
```

CC @theHenks 

CC @apmypb - now we need this to work using `LHDataStore` as well.