### PR TITLE
Support ArraysOfArrays v1 and EncodedArrays v0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendHDF5IO"
 uuid = "c9265ca6-b027-5446-b1a4-febfa8dd10b0"
-version = "0.1.18"
+version = "0.1.19"
 
 [deps]
 ArraysOfArrays = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"

--- a/Project.toml
+++ b/Project.toml
@@ -24,9 +24,9 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 LegendHDF5IOMeasurementsExt = "Measurements"
 
 [compat]
-ArraysOfArrays = "0.5, 0.6"
+ArraysOfArrays = "0.5, 0.6, 1"
 ElasticArrays = "1"
-EncodedArrays = "0.4"
+EncodedArrays = "0.4, 0.5"
 H5Zzstd = "0.1.2"
 HDF5 = "0.16.16, 0.17"
 LegendDataTypes = "0.1.6"

--- a/src/generic_io.jl
+++ b/src/generic_io.jl
@@ -462,7 +462,7 @@ function LegendDataTypes.readdata(
         L_expected = SV.parameters[1].parameters[1][1]
         L_expected == L || throw(ErrorException("Trying to read array of static vectors of length $L_expected, but inner dimension of data has length $L"))
     end
-    nestedview(data, SVector{L})
+    reinterpret(reshape, SVector{L, eltype(data)}, data)
 end
 
 
@@ -638,7 +638,7 @@ function LegendDataTypes.readdata(
     input::HDF5.H5DataStore, name::AbstractString,
     AT::Type{<:AbstractVectorOfSimilarVectors}
 )
-    nestedview(readdata(input, name, AbstractArray{<:RealQuantity,2}))
+    VectorOfSimilarVectors(readdata(input, name, AbstractArray{<:RealQuantity,2}))
 end
 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -43,7 +43,13 @@ mutable struct LH5Array{T, N} <: AbstractArray{T, N}
     file::HDF5.Dataset
 end
 
-const LH5AoSA{T, M, N, L} = ArrayOfSimilarArrays{T, M, N, L, LH5Array{T, L}}
+# ArraysOfArrays v1 replaces the data dimensionality parameter of
+# ArrayOfSimilarArrays by the element type:
+@static if isdefined(ArraysOfArrays, :PartsView)
+    const LH5AoSA{T, M, N, L} = ArrayOfSimilarArrays{T, M, N, LH5Array{T, L}}
+else
+    const LH5AoSA{T, M, N, L} = ArrayOfSimilarArrays{T, M, N, L, LH5Array{T, L}}
+end
 const LHIndexType = Union{Colon, AbstractRange{Int}}
 const VectorOfRDWaveforms{T, U, VVT, VVU} = ArrayOfRDWaveforms{T, U, 1, VVT, VVU}
 const LH5VoV{T} = VectorOfVectors{T, LH5Array{T, 1}}
@@ -104,9 +110,7 @@ return an `ArraysOfSimilarArrays` where the field `data` is a `LH5Array`
 """
 LH5Array(ds::HDF5.Dataset, 
 ::Type{<:AbstractArrayOfSimilarArrays{<:RealQuantity}}) = begin
-    A = LH5Array(ds, AbstractArray{<:RealQuantity})
-    D = _ndims(A)
-    D == 2 ? nestedview(A) : nestedview(A, Val(D - 1))
+    VectorOfSimilarArrays(LH5Array(ds, AbstractArray{<:RealQuantity}))
 end
 """
     LH5Array(ds::HDF5.Dataset, ::Type{<:NamedTuple{T}}) where T
@@ -267,6 +271,11 @@ end
 
 _inv_element_ptrs(el_ptr::AbstractVector{<:Int}) = UInt32.(el_ptr .- 1)[2:end]
 
+function _append_elemptr!(dest_ptr::AbstractVector{<:Integer}, src_ptr::AbstractVector{<:Integer})
+    offset = last(dest_ptr) - first(src_ptr)
+    append!(dest_ptr, view(src_ptr, firstindex(src_ptr) + 1:lastindex(src_ptr)) .+ offset)
+end
+
 Base.size(lh::LH5Array{T, N}) where {T, N} = begin
     dspace = HDF5.dataspace(lh.file)
     try
@@ -300,8 +309,8 @@ end
 
 Base.append!(dest::LH5VoV, src::VectorOfVectors) = begin
     if !isempty(src)
-        append!(dest.data, src.data)
-        ArraysOfArrays.append_elemptr!(dest.elem_ptr, src.elem_ptr)
+        append!(dest.data, flatview(src))
+        _append_elemptr!(dest.elem_ptr, src.elem_ptr)
         append!(dest.kernel_size, src.kernel_size)
 
         # prepare elem_ptr to append to "cumulative_length"

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -52,13 +52,13 @@ using Unitful
                     @test lhd["y"][:] == y
                 end
                 @testset "IO of VectorOfVectors" begin
-                    vofvec = VectorOfVectors(
+                    vofvec = VectorOfArrays(
                         [rand(-5:5, rand(1:100)) for _ in 1:50])
                     @test setindex!(lhd, vofvec, "vofvec") |> isnothing
                     @test lhd["vofvec"][:] == vofvec
                 end
                 @testset "IO of VectorOfSimilarVectors" begin
-                    vofsimvec = VectorOfSimilarVectors(
+                    vofsimvec = convert(VectorOfSimilarVectors,
                         [rand(-5:5, 100) for _ in 1:50])
                     @test setindex!(lhd, vofsimvec, "vofsimvec") |> isnothing
                     @test lhd["vofsimvec"][:] == vofsimvec
@@ -84,7 +84,7 @@ using Unitful
                 @testset "IO of VectorOfEncodedArrays" begin
                     codec = VarlenDiffArrayCodec()
                     data = [rand(-5:5, rand(1:100)) for _ in 1:50]
-                    vofvec = VectorOfVectors(data)
+                    vofvec = VectorOfArrays(data)
                     vofvec_enc = broadcast(|>, vofvec, codec)
                     @test setindex!(lhd, vofvec_enc, "vofvec_enc") |> isnothing
                     @test lhd["vofvec_enc"][:] == vofvec_enc
@@ -92,13 +92,13 @@ using Unitful
                 @testset "IO of VectorOfEncodedSimilarArrays" begin
                     codec = VarlenDiffArrayCodec()
                     data = [rand(-5:5, 100) for _ in 1:50]
-                    vofsimvec = VectorOfSimilarVectors(data)
+                    vofsimvec = convert(VectorOfSimilarVectors, data)
                     vofsimvec_enc = broadcast(|>, vofsimvec, codec)
                     @test setindex!(lhd, vofsimvec_enc, "vofsimvec_enc") |> isnothing
                     @test lhd["vofsimvec_enc"][:] == vofsimvec_enc
                 end
                 @testset "IO of ArrayOfRDWaveforms" begin
-                    data = nestedview(rand(UInt16, 50, 50)*u"m")
+                    data = VectorOfSimilarVectors(rand(UInt16, 50, 50)*u"m")
                     trng = range(0.0u"μs", 10.0u"μs"; length=50)
                     waveform = ArrayOfRDWaveforms((fill(trng, 50), data))
                     @test setindex!(lhd, waveform, "waveform") |> isnothing
@@ -138,19 +138,19 @@ using Unitful
                 end
                 @testset "append VectorOfVectors" begin
                     data = collect(eachcol(rand(55, 50)*u"m"))
-                    vofv = VectorOfVectors(data)
+                    vofv = VectorOfArrays(data)
                     newvofv = vcat(vofv, vofv)
                     lhd["vofv"] = vofv
                     @test append!(lhd["vofv"], vofv)[:] == newvofv
                 end
                 @testset "append VectorOfSimilarVectors" begin
-                    aofa = nestedview(rand(UInt16, 55, 50)*u"m")
+                    aofa = VectorOfSimilarVectors(rand(UInt16, 55, 50)*u"m")
                     newaofa = vcat(aofa, aofa)
                     lhd["aofa"] = aofa
                     @test append!(lhd["aofa"], aofa)[:] == newaofa
                 end
                 @testset "append VectorOfRDWaveforms" begin
-                    aofa = nestedview(rand(UInt16, 55, 50)*u"m")
+                    aofa = VectorOfSimilarVectors(rand(UInt16, 55, 50)*u"m")
                     trng = range(0.0u"μs", 10.0u"μs"; length=55)
                     waveform = ArrayOfRDWaveforms((fill(trng, 50), aofa))
                     new_waveform = vcat(waveform, waveform)


### PR DESCRIPTION
Adds compatibility with ArraysOfArrays v1 and EncodedArrays v0.5 (the release adapted to ArraysOfArrays v1), keeping support for the previous versions.

* The `LH5AoSA` alias follows the changed type parameters of `ArrayOfSimilarArrays` (`{T,M,N,P,ET}` in v1, selected via `@static if`).
* The `VectorOfSimilarArrays`/`VectorOfSimilarVectors` constructors and `reinterpret(reshape, ...)` replace the deprecated `nestedview`, available on all supported versions.
* `append!` for stored vectors of vectors used the ArraysOfArrays internal `append_elemptr!` (renamed in v1); it now uses a local helper and appends only element-covered data (`flatview`), which is what v1 requires.
* Tests use constructor forms available on all supported versions.

Verified with a targeted script against ArraysOfArrays 1.0.1 and EncodedArrays 0.5.0 (write/read and `append!` of vectors of (similar) vectors, encoded vectors, waveforms; static-vector and similar-vectors `readdata`). CI can exercise the new versions once EncodedArrays 0.5 is registered.

Includes a patch version bump.

Created by generative AI.
